### PR TITLE
fixed timer

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -1,49 +1,32 @@
-/*
-This module contains action creators. They are functions which will return an object describing the actions.
-These actions are imported by Redux-aware components who need them, in our case it is just Home.
-*/
-
 import constants from './constants';
 
-export default 
-{ 
-	setTimer(timerTime) {
-	    return {
-	        type: constants.TIMER_SET,
-	        timerTime:timerTime
-	    };
-   	},
+export default { 
 
-   	/*
-	Som man ser här har vi ju lite issues för att tickTimer får ju ingen dispatch, getState... 
-	Så jag.. ja jag vet inte riktigt ;) 
-   	*/
+    setTimer(timerTime) {
+        return {
+            type: constants.TIMER_SET,
+            timerTime:timerTime
+        };
+    },
 
-   	tickTimer() {
-   		return (dispatch, getState) => {
-   			alert("Här har vi problemet! \nDispatch: "+dispatch+"\nGetState:"+getState);
-   			dispatch({
-   				type:constants.TIMER_TICK,
-   				decrement:1000
-   			});
-   		};
-   	},
+    startTimer() {
+        return (dispatch,getState) => {
+            let tick = ()=> {
+                if (getState().timer.timerOn){
+                    dispatch({
+                        type: constants.TIMER_TICK,
+                        decrement: 1000
+                    });
+                    setTimeout(tick,1000);
+                }
+            };
+            dispatch({ type: constants.TIMER_START });
+            tick();
+        };
+    },
 
-
-   	startTimer() {
-   		return () => {
-   			dispatch({
-   				type:constants.TIMER_START
-   			});
-
-   		setTimeout(this.tickTimer(dispatch,getState),1000);
-   		};
-   	},
-
-	stopTimer() {
-	    return {
-	        type: constants.TIMER_STOP
-	    };
-   	}
+    stopTimer() {
+        return { type: constants.TIMER_STOP };
+    }
 
 };

--- a/src/components/timer.js
+++ b/src/components/timer.js
@@ -3,38 +3,37 @@ import {connect} from 'react-redux';
 import actions from '../actions';
 
 
-class Timer extends React.Component 
-{
-    render() 
-    {
-        let tOn=this.props.timer.timerOn;
-       return(
-            <div>
-            <p>Tid: {this.props.timer.timerTime}</p>
-            <p>TimerOn: {tOn.toString()}</p>
-
-            {(this.props.timer.timerTime===0)
-                ?<form>
-                    <input type="number" id="minutes" name="minutes" min="1" max="60" defaultValue="1"/>
-                    <button type="button" onClick={this.props.setTimer}>Set timer</button>
-                </form>
-                :<h1>Timer: </h1>
-            }
-            {(this.props.timer.timerOn===false && this.props.timer.timerTime!=0)
-                ?<button type="button" onClick={this.props.startTimer}>Start</button>
-                :null
-            }
-            {(this.props.timer.timerOn===true && this.props.timer.timerTime!=0)
-                ?<button type="button" onClick={this.props.stopTimer}>Stop</button>
-                :null
-            }
-          </div>
-            );
-    }
+let Timer = (props)=> {
+    let tOn=props.timer.timerOn;
+    return <div>
+        <p>Tid: {props.timer.timerTime}</p>
+        <p>TimerOn: {tOn.toString()}</p>
+        {(props.timer.timerTime===0)
+            ?<form>
+                <input type="number" id="minutes" name="minutes" min="1" max="60" defaultValue="1"/>
+                <button type="button" onClick={props.setTimer}>Set timer</button>
+            </form>
+            :<h1>Timer: </h1>
+        }
+        {(props.timer.timerOn===false && props.timer.timerTime!=0)
+            ?<button type="button" onClick={props.startTimer}>Start</button>
+            :null
+        }
+        {(props.timer.timerOn===true && props.timer.timerTime!=0)
+            ?<button type="button" onClick={props.stopTimer}>Stop</button>
+            :null
+        }
+    </div>;
 }
 
 Timer.propTypes = {
-    timerTime:PropTypes.number.isRequired
+    timer: PropTypes.shape({
+        timerTime: PropTypes.number.isRequired,
+        timerOn: PropTypes.bool.isRequired
+    }),
+    startTimer: PropTypes.func.isRequired,
+    stopTimer: PropTypes.func.isRequired,
+    setTimer: PropTypes.func.isRequired
 };
 
 let mapStateToProps = (state) => {
@@ -46,8 +45,8 @@ let mapStateToProps = (state) => {
 let mapDispatchToProps = (dispatch) => {
     return {
         setTimer() { 
-            var minutes = document.getElementById("minutes");
-            var milliSeconds = minutes.value*60*1000;
+            let minutes = document.getElementById("minutes"),
+                milliSeconds = minutes.value*60*1000;
             dispatch(actions.setTimer(milliSeconds)); 
         },
         startTimer() {
@@ -55,10 +54,6 @@ let mapDispatchToProps = (dispatch) => {
         },
         stopTimer() {
             dispatch(actions.stopTimer());
-        },
-
-        timerTick() {
-            dispatch(actions.timerTick());
         }
     };
 };

--- a/src/reducers/timer.js
+++ b/src/reducers/timer.js
@@ -15,9 +15,8 @@ export default (state,action) => {
         newstate.timerOn=false;
         return newstate;
     case C.TIMER_TICK:
-        alert("Here");
         newstate.timerTime-=action.decrement;
-    	return newstate;
+        return newstate;
     default: return state || initialState().timer;
     }
 };


### PR DESCRIPTION
This PR fixes timer functionality. The main changes are in `src/actions/timer`. Your main mistake was to think of `tickTimer` as an action creator that the app can call - it's not! The only action creators are `setTimer`, `startTimer` and `stopTimer`. However, when we `startTimer`, two things happen:
-    we synchronously dispatch `start` which will make the reducer set the `timerOn` flag
-    we call the tick function which will check to see if the timer is on (which it will be the first tick), and if so it will dispatch `tick` to make the reducer reduce (haha) the time and then it will call itself again 1000 ms later.

I also couldn't keep myself from rephrasing the `timer` component using the new stateless component syntax in React 0.14, sorry about that. :)
